### PR TITLE
Persistence exercise

### DIFF
--- a/childs-stephen/persistence/persistence_alias.py
+++ b/childs-stephen/persistence/persistence_alias.py
@@ -47,7 +47,7 @@ def load_int(reader, value, seen):
 
 def load_list(reader, value, seen):
     num_items = int(value)
-    return [load(reader) for _ in range(num_items)]
+    return [load(reader, seen) for _ in range(num_items)]
 
 
 def load_str(reader, value, seen):
@@ -62,11 +62,11 @@ LOAD = {"int": load_int, "list": load_list, "str": load_str}
 def load(reader, seen):
     kind, ident, value = reader.readline().split(":", maxsplit=2)
     if kind == "alias":
-        assert value in seen
+        assert ident in seen
         return seen[ident]
     assert kind in LOAD, f"Unknown kind {kind}"
     func = LOAD[kind]
-    result = func(reader, value)
+    result = func(reader, value, seen)
     seen[ident] = result
     return result
 
@@ -79,6 +79,7 @@ TESTS = [
     ("plain string", "hello"),
     ("multiline string", "hello\nthere\n"),
     ("everything", [17, "\nhello\n", ["there"]]),
+    ("same string twice", ["shared", "shared"]),
 ]
 
 for name, fixture in TESTS:

--- a/childs-stephen/persistence/persistence_alias.py
+++ b/childs-stephen/persistence/persistence_alias.py
@@ -28,7 +28,7 @@ def save_str(writer, thing, seen):
 SAVE = {"int": save_int, "list": save_list, "str": save_str}
 
 
-def save(writer, thing, seen)):
+def save(writer, thing, seen):
     thing_id = id(thing)
     if thing_id in seen:
         print(f"alias:{thing_id}", file=writer)
@@ -77,7 +77,7 @@ TESTS = [
 
 for name, fixture in TESTS:
     writer = io.StringIO()
-    save(writer, fixture)
+    save(writer, fixture, seen)
     content = writer.getvalue()
     reader = io.StringIO(content)
     result = load(reader)

--- a/childs-stephen/persistence/persistence_alias.py
+++ b/childs-stephen/persistence/persistence_alias.py
@@ -71,6 +71,8 @@ def load(reader, seen):
     return result
 
 
+test_list = [17, 18, 19]
+
 TESTS = [
     ("plain integer", 5),
     ("empty list", []),
@@ -79,7 +81,9 @@ TESTS = [
     ("plain string", "hello"),
     ("multiline string", "hello\nthere\n"),
     ("everything", [17, "\nhello\n", ["there"]]),
+    ("same int twice", [17, 17, 18]),
     ("same string twice", ["shared", "shared"]),
+    ("same list twice", [test_list, test_list, [17, 18, 20]]),
 ]
 
 for name, fixture in TESTS:

--- a/childs-stephen/persistence/persistence_alias.py
+++ b/childs-stephen/persistence/persistence_alias.py
@@ -1,0 +1,85 @@
+"""A very simple persistence framework."""
+
+import io
+
+seen = set()
+
+
+def save_int(writer, thing, seen):
+    assert isinstance(thing, int)
+    print(f"int:{thing}", file=writer)
+
+
+def save_list(writer, thing, seen):
+    assert isinstance(thing, list)
+    print(f"list:{len(thing)}", file=writer)
+    for item in thing:
+        save(writer, item, seen)
+
+
+def save_str(writer, thing, seen):
+    assert isinstance(thing, str)
+    lines = thing.split("\n")
+    print(f"str:{len(lines)}", file=writer)
+    for ln in lines:
+        print(ln, file=writer)
+
+
+SAVE = {"int": save_int, "list": save_list, "str": save_str}
+
+
+def save(writer, thing, seen)):
+    thing_id = id(thing)
+    if thing_id in seen:
+        print(f"alias:{thing_id}", file=writer)
+        return
+    seen.add(id(thing))
+    typename = type(thing).__name__
+    assert typename in SAVE, f"Unknown type {typename}"
+    func = SAVE[typename]
+    func(writer, thing, seen)
+
+
+def load_int(reader, value):
+    return int(value)
+
+
+def load_list(reader, value):
+    num_items = int(value)
+    return [load(reader) for _ in range(num_items)]
+
+
+def load_str(reader, value):
+    num_lines = int(value)
+    lines = [reader.readline().rstrip("\n") for _ in range(num_lines)]
+    return "\n".join(lines)
+
+
+LOAD = {"int": load_int, "list": load_list, "str": load_str}
+
+
+def load(reader):
+    kind, value = reader.readline().split(":", maxsplit=1)
+    assert kind in LOAD, f"Unknown kind {kind}"
+    func = LOAD[kind]
+    return func(reader, value)
+
+
+TESTS = [
+    ("plain integer", 5),
+    ("empty list", []),
+    ("flat list", [88, 99, 100]),
+    ("nested list", [17, 18, [19]]),
+    ("plain string", "hello"),
+    ("multiline string", "hello\nthere\n"),
+    ("everything", [17, "\nhello\n", ["there"]]),
+]
+
+for name, fixture in TESTS:
+    writer = io.StringIO()
+    save(writer, fixture)
+    content = writer.getvalue()
+    reader = io.StringIO(content)
+    result = load(reader)
+    print(f"{name}\n{content}")
+    assert result == fixture, f"Test failed: {name}"

--- a/childs-stephen/persistence/persistence_globals.py
+++ b/childs-stephen/persistence/persistence_globals.py
@@ -1,0 +1,75 @@
+"""A very simple persistence framework."""
+
+import io
+
+def save_int(writer, thing):
+    assert isinstance(thing, int)
+    print(f"int:{thing}", file=writer)
+
+def save_list(writer, thing):
+    assert isinstance(thing, list)
+    print(f"list:{len(thing)}", file=writer)
+    for item in thing:
+        save(writer, item)
+
+def save_str(writer, thing):
+    assert isinstance(thing, str)
+    lines = thing.split("\n")
+    print(f"str:{len(lines)}", file=writer)
+    for ln in lines:
+        print(ln, file=writer)
+
+SAVE = {
+    "int": save_int,
+    "list": save_list,
+    "str": save_str
+}
+
+def save(writer, thing):
+    typename = type(thing).__name__
+    assert typename in SAVE, f"Unknown type {typename}"
+    func = SAVE[typename]
+    func(writer, thing)
+
+def load_int(reader, value):
+    return int(value)
+
+def load_list(reader, value):
+    num_items = int(value)
+    return [load(reader) for _ in range(num_items)]
+
+def load_str(reader, value):
+    num_lines = int(value)
+    lines = [reader.readline().rstrip("\n") for _ in range(num_lines)]
+    return "\n".join(lines)
+
+LOAD = {
+    "int": load_int,
+    "list": load_list,
+    "str": load_str
+}
+
+def load(reader):
+    kind, value = reader.readline().split(":", maxsplit=1)
+    assert kind in LOAD, f"Unknown kind {kind}"
+    func = LOAD[kind]
+    return func(reader, value)
+
+TESTS = [
+    ("plain integer", 5),
+    ("empty list", []),
+    ("flat list", [88, 99, 100]),
+    ("nested list", [17, 18, [19]]),
+    ("plain string", "hello"),
+    ("multiline string", "hello\nthere\n"),
+    ("everything", [17, "\nhello\n", ["there"]])
+]
+
+for (name, fixture) in TESTS:
+    writer = io.StringIO()
+    save(writer, fixture)
+    content = writer.getvalue()
+    reader = io.StringIO(content)
+    result = load(reader)
+    print(f"{name}\n{content}")
+    assert result == fixture, f"Test failed: {name}"

--- a/childs-stephen/persistence/persistence_globals.py
+++ b/childs-stephen/persistence/persistence_globals.py
@@ -8,6 +8,11 @@ def save_int(writer, thing):
     print(f"int:{thing}", file=writer)
 
 
+def save_float(writer, thing):
+    assert isinstance(thing, float)
+    print(f"float:{thing}", file=writer)
+
+
 def save_list(writer, thing):
     assert isinstance(thing, list)
     print(f"list:{len(thing)}", file=writer)
@@ -41,6 +46,10 @@ def load_int(reader, value):
     return int(value)
 
 
+def load_float(reader, value):
+    return float(value)
+
+
 def load_list(reader, value):
     num_items = int(value)
     return [load(reader) for _ in range(num_items)]
@@ -68,6 +77,7 @@ def load(reader):
 
 TESTS = [
     ("plain integer", 5),
+    ("plain float", 4.2),
     ("empty list", []),
     ("flat list", [88, 99, 100]),
     ("nested list", [17, 18, [19]]),

--- a/childs-stephen/persistence/persistence_globals.py
+++ b/childs-stephen/persistence/persistence_globals.py
@@ -2,15 +2,18 @@
 
 import io
 
+
 def save_int(writer, thing):
     assert isinstance(thing, int)
     print(f"int:{thing}", file=writer)
+
 
 def save_list(writer, thing):
     assert isinstance(thing, list)
     print(f"list:{len(thing)}", file=writer)
     for item in thing:
         save(writer, item)
+
 
 def save_str(writer, thing):
     assert isinstance(thing, str)
@@ -19,11 +22,13 @@ def save_str(writer, thing):
     for ln in lines:
         print(ln, file=writer)
 
+
 SAVE = {
-    "int": save_int,
-    "list": save_list,
-    "str": save_str
+    n.split("_", maxsplit=1)[1]: globals()[n]
+    for n in globals()
+    if n.startswith("save_")
 }
+
 
 def save(writer, thing):
     typename = type(thing).__name__
@@ -31,29 +36,35 @@ def save(writer, thing):
     func = SAVE[typename]
     func(writer, thing)
 
+
 def load_int(reader, value):
     return int(value)
+
 
 def load_list(reader, value):
     num_items = int(value)
     return [load(reader) for _ in range(num_items)]
+
 
 def load_str(reader, value):
     num_lines = int(value)
     lines = [reader.readline().rstrip("\n") for _ in range(num_lines)]
     return "\n".join(lines)
 
+
 LOAD = {
-    "int": load_int,
-    "list": load_list,
-    "str": load_str
+    n.split("_", maxsplit=1)[1]: globals()[n]
+    for n in globals()
+    if n.startswith("load_")
 }
+
 
 def load(reader):
     kind, value = reader.readline().split(":", maxsplit=1)
     assert kind in LOAD, f"Unknown kind {kind}"
     func = LOAD[kind]
     return func(reader, value)
+
 
 TESTS = [
     ("plain integer", 5),
@@ -62,10 +73,10 @@ TESTS = [
     ("nested list", [17, 18, [19]]),
     ("plain string", "hello"),
     ("multiline string", "hello\nthere\n"),
-    ("everything", [17, "\nhello\n", ["there"]])
+    ("everything", [17, "\nhello\n", ["there"]]),
 ]
 
-for (name, fixture) in TESTS:
+for name, fixture in TESTS:
     writer = io.StringIO()
     save(writer, fixture)
     content = writer.getvalue()

--- a/childs-stephen/persistence/persistence_strings.py
+++ b/childs-stephen/persistence/persistence_strings.py
@@ -1,0 +1,70 @@
+"""A very simple persistence framework."""
+
+import io
+
+def save_int(writer, thing):
+    assert isinstance(thing, int)
+    print(f"int:{thing}", file=writer)
+
+def save_list(writer, thing):
+    assert isinstance(thing, list)
+    print(f"list:{len(thing)}", file=writer)
+    for item in thing:
+        save(writer, item)
+
+def save_str(writer, thing):
+    assert isinstance(thing, str)
+    print(f"str:{repr(thing)}", file=writer))
+
+SAVE = {
+    "int": save_int,
+    "list": save_list,
+    "str": save_str
+}
+
+def save(writer, thing):
+    typename = type(thing).__name__
+    assert typename in SAVE, f"Unknown type {typename}"
+    func = SAVE[typename]
+    func(writer, thing)
+
+def load_int(reader, value):
+    return int(value)
+
+def load_list(reader, value):
+    num_items = int(value)
+    return [load(reader) for _ in range(num_items)]
+
+def load_str(reader, value):
+    return str(value)
+
+LOAD = {
+    "int": load_int,
+    "list": load_list,
+    "str": load_str
+}
+
+def load(reader):
+    kind, value = reader.readline().split(":", maxsplit=1)
+    assert kind in LOAD, f"Unknown kind {kind}"
+    func = LOAD[kind]
+    return func(reader, value)
+
+TESTS = [
+    ("plain integer", 5),
+    ("empty list", []),
+    ("flat list", [88, 99, 100]),
+    ("nested list", [17, 18, [19]]),
+    ("plain string", "hello"),
+    ("multiline string", "hello\nthere\n"),
+    ("everything", [17, "\nhello\n", ["there"]])
+]
+
+for (name, fixture) in TESTS:
+    writer = io.StringIO()
+    save(writer, fixture)
+    content = writer.getvalue()
+    reader = io.StringIO(content)
+    result = load(reader)
+    print(f"{name}\n{content}")
+    assert result == fixture, f"Test failed: {name}"

--- a/childs-stephen/persistence/persistence_strings.py
+++ b/childs-stephen/persistence/persistence_strings.py
@@ -17,7 +17,8 @@ def save_list(writer, thing):
 
 def save_str(writer, thing):
     assert isinstance(thing, str)
-    print(f"str:{repr(thing)}", file=writer)
+    fixed_string = thing.replace("\n", r"\n")
+    print(f"str:{fixed_string}", file=writer)
 
 
 SAVE = {"int": save_int, "list": save_list, "str": save_str}

--- a/childs-stephen/persistence/persistence_strings.py
+++ b/childs-stephen/persistence/persistence_strings.py
@@ -1,6 +1,7 @@
 """A very simple persistence framework."""
 
 import io
+import re
 
 
 def save_int(writer, thing):
@@ -41,7 +42,8 @@ def load_list(reader, value):
 
 
 def load_str(reader, value):
-    fixed_string = str(value).replace(r"\n", "\n")
+    strip_last_newline = re.sub("\n$", "", str(value))
+    fixed_string = strip_last_newline.replace(r"\n", "\n")
     return fixed_string
 
 

--- a/childs-stephen/persistence/persistence_strings.py
+++ b/childs-stephen/persistence/persistence_strings.py
@@ -2,9 +2,11 @@
 
 import io
 
+
 def save_int(writer, thing):
     assert isinstance(thing, int)
     print(f"int:{thing}", file=writer)
+
 
 def save_list(writer, thing):
     assert isinstance(thing, list)
@@ -12,15 +14,14 @@ def save_list(writer, thing):
     for item in thing:
         save(writer, item)
 
+
 def save_str(writer, thing):
     assert isinstance(thing, str)
-    print(f"str:{repr(thing)}", file=writer))
+    print(f"str:{repr(thing)}", file=writer)
 
-SAVE = {
-    "int": save_int,
-    "list": save_list,
-    "str": save_str
-}
+
+SAVE = {"int": save_int, "list": save_list, "str": save_str}
+
 
 def save(writer, thing):
     typename = type(thing).__name__
@@ -28,27 +29,29 @@ def save(writer, thing):
     func = SAVE[typename]
     func(writer, thing)
 
+
 def load_int(reader, value):
     return int(value)
+
 
 def load_list(reader, value):
     num_items = int(value)
     return [load(reader) for _ in range(num_items)]
 
+
 def load_str(reader, value):
     return str(value)
 
-LOAD = {
-    "int": load_int,
-    "list": load_list,
-    "str": load_str
-}
+
+LOAD = {"int": load_int, "list": load_list, "str": load_str}
+
 
 def load(reader):
     kind, value = reader.readline().split(":", maxsplit=1)
     assert kind in LOAD, f"Unknown kind {kind}"
     func = LOAD[kind]
     return func(reader, value)
+
 
 TESTS = [
     ("plain integer", 5),
@@ -57,10 +60,10 @@ TESTS = [
     ("nested list", [17, 18, [19]]),
     ("plain string", "hello"),
     ("multiline string", "hello\nthere\n"),
-    ("everything", [17, "\nhello\n", ["there"]])
+    ("everything", [17, "\nhello\n", ["there"]]),
 ]
 
-for (name, fixture) in TESTS:
+for name, fixture in TESTS:
     writer = io.StringIO()
     save(writer, fixture)
     content = writer.getvalue()

--- a/childs-stephen/persistence/persistence_strings.py
+++ b/childs-stephen/persistence/persistence_strings.py
@@ -41,7 +41,8 @@ def load_list(reader, value):
 
 
 def load_str(reader, value):
-    return str(value)
+    fixed_string = str(value).replace(r"\n", "\n")
+    return fixed_string
 
 
 LOAD = {"int": load_int, "list": load_list, "str": load_str}


### PR DESCRIPTION
This one took me a bit longer to finish up.

In answer to part 2 of the globals exercise, the main reason I think it could be a bad idea to use globals is that you could catch an unrelated function that follows the same naming scheme.

I thought it might be a security issue, but I can't quite figure out how to swap out the functions. :)